### PR TITLE
Parameter "format" zu /records/count hinzugefügt

### DIFF
--- a/resources/swagger/openapi.json
+++ b/resources/swagger/openapi.json
@@ -60,6 +60,9 @@
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/query"
+                    },
+                    {
+                        "$ref": "#/components/parameters/formatInQuery"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
Wie in Ticket #8829 besprochen, hier die Änderung an der `openapi.json` für den zusätzlichen Parameter `format` im Endpunkt `/records/count`.